### PR TITLE
Update README with install instructions for raspberry pi

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,15 @@ https://github.com/rickybiscus/plugin.video.auvio
 * Stream live videos and radios, video replays and audio podcasts
 
 ## Installation
+
+### Raspberry Pi (LibreELEC, OpenELEC, OSMC)
+* Connect to your RPI via SSH
+* Navigate to your `.kodi/addons/` folder: `cd .kodi/addons/`
+* Fetch the plugin (download, extract then remove the master.zip) : `wget https://github.com/rickybiscus/plugin.video.auvio/archive/master.zip; unzip master.zip; rm master.zip`
+* Rename the new folder in "plugin.video.auvio": `mv plugin.video.auvio-master plugin.video.auvio`
+* (Re)start Kodi: `reboot`
+
+### Other
 * Navigate to your `.kodi/addons/` folder
 * Clone this repository: `git clone https://github.com/rickybiscus/plugin.video.auvio.git`
 * (Re)start Kodi.


### PR DESCRIPTION
Related issue: #20 

This is a small update for your README to include the right instructions to install the plugin on a Raspberry pi. 

Regards,

Alexis