### PR TITLE
redbee without DRM support added

### DIFF
--- a/lib/redbee.py
+++ b/lib/redbee.py
@@ -120,6 +120,11 @@ def get_redbee_media_url(media_id, session_token):
     
     for fmt in data['formats']:
         if fmt['format'] == 'DASH':
+            if "drm" in fmt:
+                return fmt
+
+    for fmt in data['formats']:
+        if fmt['format'] == 'HLS':
             return fmt
-    
+
     return ''

--- a/main.py
+++ b/main.py
@@ -365,10 +365,11 @@ def play_media(**params):
 
         # Get media URL
         media_data = redbee.get_redbee_media_url(mid, redbee_jwt['sessionToken'])        
-        if media_data:
+        if "mediaLocator" in media_data:
             media_url = media_data['mediaLocator']
-            media_drmlicense = media_data['drm']['com.widevine.alpha']['licenseServerUrl']
-            common.plugin.log("media #{0} drm license: {1}".format(mid,media_drmlicense),xbmc.LOGINFO)
+            if "drm" in media_data:
+                media_drmlicense = media_data['drm']['com.widevine.alpha']['licenseServerUrl']
+                common.plugin.log("media #{0} drm license: {1}".format(mid,media_drmlicense),xbmc.LOGINFO)
 
     if media_url:
 


### PR DESCRIPTION
redbee.py: use DASH if with DRM, use HLS if without DRM
main.py: check playback DRM-license
